### PR TITLE
♻️ [Refactoring]: index.tsのテキストエリア検出ロジックを別ファイルに抽出

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "keywords": [
     "chrome-extension",
@@ -19,7 +21,10 @@
   "packageManager": "pnpm@10.13.1",
   "devDependencies": {
     "@types/chrome": "^0.0.332",
+    "@vitest/browser": "^3.2.4",
+    "happy-dom": "^18.0.1",
     "typescript": "^5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,51 +1,54 @@
-import { 
-  INDENT_SIZE, 
-  INDENT_STRING, 
-  SUPPORTED_ELEMENTS, 
-  KEY_CODES, 
-  EVENT_TYPES 
-} from './constants';
+import {
+  INDENT_SIZE,
+  INDENT_STRING,
+  KEY_CODES,
+  EVENT_TYPES,
+} from "./constants";
+import { getTextAreaElement } from "./textareaDetector";
 
 function handleTabKey(event: KeyboardEvent): void {
-  if (event.key !== KEY_CODES.TAB) return;
-  
-  const target = event.target as HTMLTextAreaElement | HTMLInputElement;
-  
-  if (!target || !SUPPORTED_ELEMENTS.includes(target.tagName as any)) {
+  if (event.key !== KEY_CODES.TAB) {
     return;
   }
-  
+
+  const target = getTextAreaElement(event);
+
+  if (!target) {
+    return;
+  }
+
   event.preventDefault();
-  
+
   const start = target.selectionStart;
   const end = target.selectionEnd;
   const value = target.value;
-  
+
   if (start === null || end === null) {
     return;
   }
-  
+
   if (event.shiftKey) {
     const beforeCursor = value.substring(0, start);
     const afterCursor = value.substring(end);
-    
-    const lines = beforeCursor.split('\n');
+
+    const lines = beforeCursor.split("\n");
     const currentLine = lines[lines.length - 1];
-    
+
     if (currentLine.startsWith(INDENT_STRING)) {
       const newValue = value.substring(0, start - INDENT_SIZE) + afterCursor;
       target.value = newValue;
       target.selectionStart = target.selectionEnd = start - INDENT_SIZE;
     }
   } else {
-    const newValue = value.substring(0, start) + INDENT_STRING + value.substring(end);
+    const newValue =
+      value.substring(0, start) + INDENT_STRING + value.substring(end);
     target.value = newValue;
     target.selectionStart = target.selectionEnd = start + INDENT_SIZE;
   }
-  
+
   target.dispatchEvent(new Event(EVENT_TYPES.INPUT, { bubbles: true }));
 }
 
 document.addEventListener(EVENT_TYPES.KEYDOWN, handleTabKey, true);
 
-console.log('GitHub Tab Indent Extension loaded');
+console.log("GitHub Tab Indent Extension loaded");

--- a/src/content/textareaDetector.test.ts
+++ b/src/content/textareaDetector.test.ts
@@ -1,0 +1,81 @@
+import { isValidTextArea, getTextAreaElement } from './textareaDetector';
+
+describe('textareaDetector', () => {
+  describe('isValidTextArea', () => {
+    describe('正常系', () => {
+      it('HTMLTextAreaElementを渡した場合、trueを返す', () => {
+        const textarea = document.createElement('textarea');
+        const result = isValidTextArea(textarea);
+        expect(result).toBe(true);
+      });
+
+      it('HTMLInputElementを渡した場合、trueを返す', () => {
+        const input = document.createElement('input');
+        input.type = 'text';
+        const result = isValidTextArea(input);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('異常系', () => {
+      it('undefinedを渡した場合、falseを返す', () => {
+        const result = isValidTextArea(undefined);
+        expect(result).toBe(false);
+      });
+
+      it('divなどのサポートされていない要素を渡した場合、falseを返す', () => {
+        const div = document.createElement('div');
+        const result = isValidTextArea(div);
+        expect(result).toBe(false);
+      });
+
+      it('HTMLElement以外のEventTargetを渡した場合、falseを返す', () => {
+        const xmlHttpRequest = new XMLHttpRequest();
+        const result = isValidTextArea(xmlHttpRequest);
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('getTextAreaElement', () => {
+    describe('正常系', () => {
+      it('textareaをターゲットとするKeyboardEventの場合、textareaを返す', () => {
+        const textarea = document.createElement('textarea');
+        const event = new KeyboardEvent('keydown', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: textarea, writable: false });
+        
+        const result = getTextAreaElement(event);
+        expect(result).toBe(textarea);
+      });
+
+      it('inputをターゲットとするKeyboardEventの場合、inputを返す', () => {
+        const input = document.createElement('input');
+        input.type = 'text';
+        const event = new KeyboardEvent('keydown', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: input, writable: false });
+        
+        const result = getTextAreaElement(event);
+        expect(result).toBe(input);
+      });
+    });
+
+    describe('異常系', () => {
+      it('targetがnullのKeyboardEventの場合、undefinedを返す', () => {
+        const event = new KeyboardEvent('keydown', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: null, writable: false });
+        
+        const result = getTextAreaElement(event);
+        expect(result).toBeUndefined();
+      });
+
+      it('divをターゲットとするKeyboardEventの場合、undefinedを返す', () => {
+        const div = document.createElement('div');
+        const event = new KeyboardEvent('keydown', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: div, writable: false });
+        
+        const result = getTextAreaElement(event);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/content/textareaDetector.ts
+++ b/src/content/textareaDetector.ts
@@ -1,0 +1,52 @@
+import { SUPPORTED_ELEMENTS, type SupportedElement } from "./constants";
+
+export type EditableElement = HTMLTextAreaElement | HTMLInputElement;
+
+function hasSelectionCapability(element: HTMLElement): element is EditableElement {
+  if (!(element instanceof HTMLTextAreaElement || element instanceof HTMLInputElement)) {
+    return false;
+  }
+  
+  return (
+    element.selectionStart !== undefined && 
+    element.selectionStart !== null &&
+    element.selectionEnd !== undefined && 
+    element.selectionEnd !== null
+  );
+}
+
+function isSupportedElement(tagName: string): tagName is SupportedElement {
+  return SUPPORTED_ELEMENTS.includes(tagName as SupportedElement);
+}
+
+export function isValidTextArea(
+  target: EventTarget | undefined
+): target is EditableElement {
+  if (!target) {
+    return false;
+  }
+  
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  
+  const tagName = target.tagName;
+  
+  if (!isSupportedElement(tagName)) {
+    return false;
+  }
+  
+  return hasSelectionCapability(target);
+}
+
+export function getTextAreaElement(
+  event: KeyboardEvent
+): EditableElement | undefined {
+  const target = event.target ?? undefined;
+  
+  if (isValidTextArea(target)) {
+    return target;
+  }
+  
+  return undefined;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,2 @@
+// Vitest global setup file
+// Add any global test configuration here

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "types": ["chrome"]
+    "types": ["chrome", "vitest/globals"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts']
+  },
+  resolve: {
+    alias: {
+      '@': '/src'
+    }
+  }
+});


### PR DESCRIPTION
## 概要
- index.tsに実装されていたテキストエリア検出ロジックを`textareaDetector.ts`に切り出しました
- TDDアプローチでテストを先に作成し、実装を行いました

## 変更内容
### テスト環境のセットアップ
- Vitestと関連パッケージを導入
- テスト設定ファイルを作成

### リファクタリング
- `textareaDetector.ts`を新規作成
  - `isValidTextArea`関数: テキストエリアの検証
  - `getTextAreaElement`関数: イベントからテキストエリア要素を取得
  - `EditableElement`型の定義
- index.tsを更新して新しいモジュールを使用

### コード品質の改善
- `as any`キャストを削除して型安全性を向上
- `null`の代わりに`undefined`を使用して一貫性を保つ
- 関数を小さく分割して可読性を向上

## テスト
- textareaDetectorの全機能に対するユニットテストを作成
- 正常系・異常系のテストケースを網羅
- すべてのテストが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)