### PR TITLE
✨ [New Feature]: Cmd/Ctrl + [ ] ショートカットキーのサポート

### DIFF
--- a/src/content/constants.ts
+++ b/src/content/constants.ts
@@ -1,6 +1,7 @@
 export const INDENT_SIZE = 2;
 export const INDENT_CHAR = ' ';
 export const INDENT_STRING = INDENT_CHAR.repeat(INDENT_SIZE);
+export const INDENT = INDENT_STRING; // エイリアス
 
 export const SUPPORTED_ELEMENTS = ['TEXTAREA', 'INPUT'] as const;
 export type SupportedElement = typeof SUPPORTED_ELEMENTS[number];

--- a/src/content/indentHandler.test.ts
+++ b/src/content/indentHandler.test.ts
@@ -1,34 +1,67 @@
 import { describe, it, expect } from "vitest";
-import { createIndentHandler } from "./indentHandler";
+import { createIndentHandler, createIndentHandlerFromType } from "./indentHandler";
+import { addIndent, removeIndent } from "./indentProcessor";
+import { IndentActionType } from "./shortcutDetector";
 
 describe("indentHandler", () => {
   describe("createIndentHandler", () => {
-    it("shiftKeyがfalseの場合、インデント追加ハンドラーを返す", () => {
+    it("Tab単体でaddIndentハンドラーを返す", () => {
       const event = new KeyboardEvent("keydown", {
         key: "Tab",
         shiftKey: false,
       });
       
       const handler = createIndentHandler(event);
-      const result = handler("Hello World", 5, 5);
+      expect(handler).toBe(addIndent);
       
+      const result = handler?.("Hello World", 5, 5);
       expect(result).toBeDefined();
       expect(result!.newValue).toBe("Hello   World");
       expect(result!.cursorPosition).toBe(7);
     });
 
-    it("shiftKeyがtrueの場合、インデント削除ハンドラーを返す", () => {
+    it("Shift+TabでremoveIndentハンドラーを返す", () => {
       const event = new KeyboardEvent("keydown", {
         key: "Tab",
         shiftKey: true,
       });
       
       const handler = createIndentHandler(event);
-      const result = handler("  Hello World", 2, 2);
+      expect(handler).toBe(removeIndent);
       
+      const result = handler?.("  Hello World", 2, 2);
       expect(result).toBeDefined();
       expect(result!.newValue).toBe("Hello World");
       expect(result!.cursorPosition).toBe(0);
+    });
+
+    it("Cmd/Ctrl + ]でaddIndentハンドラーを返す", () => {
+      const event = new KeyboardEvent("keydown", {
+        key: "]",
+        metaKey: true,
+      });
+      
+      const handler = createIndentHandler(event);
+      expect(handler).toBe(addIndent);
+    });
+
+    it("Cmd/Ctrl + [でremoveIndentハンドラーを返す", () => {
+      const event = new KeyboardEvent("keydown", {
+        key: "[",
+        ctrlKey: true,
+      });
+      
+      const handler = createIndentHandler(event);
+      expect(handler).toBe(removeIndent);
+    });
+
+    it("対象外のキーではnullを返す", () => {
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+      });
+      
+      const handler = createIndentHandler(event);
+      expect(handler).toBeNull();
     });
 
     it("インデント削除ハンドラーでインデントがない場合はundefinedを返す", () => {
@@ -38,9 +71,26 @@ describe("indentHandler", () => {
       });
       
       const handler = createIndentHandler(event);
-      const result = handler("Hello World", 5, 5);
+      const result = handler?.("Hello World", 5, 5);
       
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("createIndentHandlerFromType", () => {
+    it("ADDタイプでaddIndentハンドラーを返す", () => {
+      const handler = createIndentHandlerFromType(IndentActionType.ADD);
+      expect(handler).toBe(addIndent);
+    });
+
+    it("REMOVEタイプでremoveIndentハンドラーを返す", () => {
+      const handler = createIndentHandlerFromType(IndentActionType.REMOVE);
+      expect(handler).toBe(removeIndent);
+    });
+
+    it("NONEタイプでnullを返す", () => {
+      const handler = createIndentHandlerFromType(IndentActionType.NONE);
+      expect(handler).toBeNull();
     });
   });
 });

--- a/src/content/indentHandler.ts
+++ b/src/content/indentHandler.ts
@@ -1,4 +1,5 @@
 import { IndentResult, addIndent, removeIndent } from "./indentProcessor";
+import { detectIndentAction, IndentActionType } from "./shortcutDetector";
 
 export type IndentHandler = (
   value: string,
@@ -6,6 +7,36 @@ export type IndentHandler = (
   selectionEnd: number
 ) => IndentResult | undefined;
 
-export function createIndentHandler(event: KeyboardEvent): IndentHandler {
-  return event.shiftKey ? removeIndent : addIndent;
+/**
+ * KeyboardEventからインデントハンドラーを作成
+ * @param event キーボードイベント
+ * @returns インデントハンドラー関数
+ */
+export function createIndentHandler(event: KeyboardEvent): IndentHandler | null {
+  const actionType = detectIndentAction(event);
+  
+  switch (actionType) {
+    case IndentActionType.ADD:
+      return addIndent;
+    case IndentActionType.REMOVE:
+      return removeIndent;
+    case IndentActionType.NONE:
+      return null;
+  }
+}
+
+/**
+ * IndentActionTypeからインデントハンドラーを作成
+ * @param actionType インデント操作のタイプ
+ * @returns インデントハンドラー関数
+ */
+export function createIndentHandlerFromType(actionType: IndentActionType): IndentHandler | null {
+  switch (actionType) {
+    case IndentActionType.ADD:
+      return addIndent;
+    case IndentActionType.REMOVE:
+      return removeIndent;
+    case IndentActionType.NONE:
+      return null;
+  }
 }

--- a/src/content/shortcutDetector.test.ts
+++ b/src/content/shortcutDetector.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect } from 'vitest';
+import { 
+  detectIndentAction, 
+  IndentActionType,
+  isTabKey,
+  isAddIndentShortcut,
+  isRemoveIndentShortcut
+} from './shortcutDetector';
+
+describe('shortcutDetector', () => {
+  describe('isTabKey', () => {
+    test('Tabキーを検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab' });
+      expect(isTabKey(event)).toBe(true);
+    });
+
+    test('Tab以外のキーは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      expect(isTabKey(event)).toBe(false);
+    });
+  });
+
+  describe('isAddIndentShortcut', () => {
+    test('Cmd + ]を検出する', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: ']',
+        metaKey: true,
+        ctrlKey: false,
+      });
+      expect(isAddIndentShortcut(event)).toBe(true);
+    });
+
+    test('Ctrl + ]を検出する', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: ']',
+        metaKey: false,
+        ctrlKey: true,
+      });
+      expect(isAddIndentShortcut(event)).toBe(true);
+    });
+
+    test('Shift付きは検出しない', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: ']',
+        metaKey: true,
+        shiftKey: true,
+      });
+      expect(isAddIndentShortcut(event)).toBe(false);
+    });
+  });
+
+  describe('isRemoveIndentShortcut', () => {
+    test('Cmd + [を検出する', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: '[',
+        metaKey: true,
+        ctrlKey: false,
+      });
+      expect(isRemoveIndentShortcut(event)).toBe(true);
+    });
+
+    test('Ctrl + [を検出する', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: '[',
+        metaKey: false,
+        ctrlKey: true,
+      });
+      expect(isRemoveIndentShortcut(event)).toBe(true);
+    });
+
+    test('Alt付きは検出しない', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: '[',
+        metaKey: true,
+        altKey: true,
+      });
+      expect(isRemoveIndentShortcut(event)).toBe(false);
+    });
+  });
+
+  describe('detectIndentAction', () => {
+    describe('Tabキー', () => {
+      test('Tab単体でADDを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Tab',
+          shiftKey: false,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.ADD);
+      });
+
+      test('Shift+TabでREMOVEを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Tab',
+          shiftKey: true,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.REMOVE);
+      });
+    });
+
+    describe('ショートカットキー', () => {
+      test('Cmd/Ctrl + ]でADDを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: ']',
+          metaKey: true,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.ADD);
+      });
+
+      test('Cmd/Ctrl + [でREMOVEを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: '[',
+          ctrlKey: true,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.REMOVE);
+      });
+    });
+
+    describe('対象外のキー', () => {
+      test('Enterキー単体はNONEを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Enter',
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.NONE);
+      });
+
+      test('修飾キーなしの]はNONEを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: ']',
+          metaKey: false,
+          ctrlKey: false,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.NONE);
+      });
+
+      test('Cmd/Ctrl + 他のキーはNONEを返す', () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'a',
+          metaKey: true,
+        });
+        expect(detectIndentAction(event)).toBe(IndentActionType.NONE);
+      });
+    });
+  });
+});

--- a/src/content/shortcutDetector.ts
+++ b/src/content/shortcutDetector.ts
@@ -1,0 +1,68 @@
+/**
+ * インデント操作のタイプ
+ */
+export enum IndentActionType {
+  /** インデント追加 */
+  ADD = 'ADD',
+  /** インデント削除 */
+  REMOVE = 'REMOVE',
+  /** 対象外のキー */
+  NONE = 'NONE'
+}
+
+/**
+ * Tabキーかどうかを判定
+ * @param event キーボードイベント
+ * @returns Tabキーの場合true
+ */
+export function isTabKey(event: KeyboardEvent): boolean {
+  return event.key === 'Tab';
+}
+
+/**
+ * インデント追加のショートカット（Cmd/Ctrl + ]）かどうかを判定
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isAddIndentShortcut(event: KeyboardEvent): boolean {
+  return event.key === ']' && 
+         (event.metaKey || event.ctrlKey) && 
+         !event.shiftKey && 
+         !event.altKey;
+}
+
+/**
+ * インデント削除のショートカット（Cmd/Ctrl + [）かどうかを判定
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isRemoveIndentShortcut(event: KeyboardEvent): boolean {
+  return event.key === '[' && 
+         (event.metaKey || event.ctrlKey) && 
+         !event.shiftKey && 
+         !event.altKey;
+}
+
+/**
+ * キーイベントからインデント操作のタイプを判定
+ * @param event キーボードイベント
+ * @returns インデント操作のタイプ
+ */
+export function detectIndentAction(event: KeyboardEvent): IndentActionType {
+  // Tabキーの場合
+  if (isTabKey(event)) {
+    return event.shiftKey ? IndentActionType.REMOVE : IndentActionType.ADD;
+  }
+  
+  // Cmd/Ctrl + ] の場合
+  if (isAddIndentShortcut(event)) {
+    return IndentActionType.ADD;
+  }
+  
+  // Cmd/Ctrl + [ の場合
+  if (isRemoveIndentShortcut(event)) {
+    return IndentActionType.REMOVE;
+  }
+  
+  return IndentActionType.NONE;
+}


### PR DESCRIPTION
## 概要
VSCode互換のインデントショートカットキー（Cmd/Ctrl + [ ]）のサポートを追加しました。

## 変更内容

### 新機能
- **Cmd/Ctrl + ]**: 行にインデントを追加
- **Cmd/Ctrl + [**: 行のインデントを削除

### 技術的変更
1. **shortcutDetector モジュールの追加**
   - `IndentActionType` enumでインデント操作を統一管理
   - `detectIndentAction`関数で全てのインデント操作キーを判定
   - Tab/Shift+TabとCmd/Ctrl+[/]を統一的に処理

2. **indentHandler の改善**
   - `shortcutDetector`と連携して動作
   - `createIndentHandlerFromType`関数を追加

3. **index.ts のリファクタリング**
   - 統一的なキー判定ロジックに変更
   - ガード節を使用して可読性を向上

## テスト計画
- [x] ユニットテスト（42テスト全てPASS）
- [x] ビルド成功確認
- [ ] Chrome拡張機能として実際に動作確認
- [ ] GitHub上でTabキーとショートカットキーの動作確認

## 実装方法
TDD（テスト駆動開発）で実装：
1. Red: 失敗するテストを作成
2. Green: テストが通る最小限の実装
3. Refactor: コードを整理

🤖 Generated with [Claude Code](https://claude.ai/code)