### PR TITLE
♻️ [Refactoring]: Tabキー判定ロジックの厳密化とコード整理

### DIFF
--- a/src/content/shortcutDetector.test.ts
+++ b/src/content/shortcutDetector.test.ts
@@ -3,8 +3,12 @@ import {
   detectIndentAction, 
   IndentActionType,
   isTabKey,
+  isAddIndentWithTab,
+  isRemoveIndentWithTab,
   isAddIndentShortcut,
-  isRemoveIndentShortcut
+  isRemoveIndentShortcut,
+  isAddIndent,
+  isRemoveIndent
 } from './shortcutDetector';
 
 describe('shortcutDetector', () => {
@@ -17,6 +21,70 @@ describe('shortcutDetector', () => {
     test('Tab以外のキーは検出しない', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
       expect(isTabKey(event)).toBe(false);
+    });
+  });
+
+  describe('isAddIndentWithTab', () => {
+    test('Tab単体を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+      expect(isAddIndentWithTab(event)).toBe(true);
+    });
+
+    test('Shift+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+      expect(isAddIndentWithTab(event)).toBe(false);
+    });
+
+    test('Ctrl+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', ctrlKey: true });
+      expect(isAddIndentWithTab(event)).toBe(false);
+    });
+
+    test('Alt+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', altKey: true });
+      expect(isAddIndentWithTab(event)).toBe(false);
+    });
+
+    test('Cmd/Meta+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', metaKey: true });
+      expect(isAddIndentWithTab(event)).toBe(false);
+    });
+
+    test('Tab以外のキーは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      expect(isAddIndentWithTab(event)).toBe(false);
+    });
+  });
+
+  describe('isRemoveIndentWithTab', () => {
+    test('Shift+Tabを検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+      expect(isRemoveIndentWithTab(event)).toBe(true);
+    });
+
+    test('Tab単体は検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+      expect(isRemoveIndentWithTab(event)).toBe(false);
+    });
+
+    test('Shift+Ctrl+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, ctrlKey: true });
+      expect(isRemoveIndentWithTab(event)).toBe(false);
+    });
+
+    test('Shift+Alt+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, altKey: true });
+      expect(isRemoveIndentWithTab(event)).toBe(false);
+    });
+
+    test('Shift+Cmd/Meta+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, metaKey: true });
+      expect(isRemoveIndentWithTab(event)).toBe(false);
+    });
+
+    test('Shift+他のキーは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true });
+      expect(isRemoveIndentWithTab(event)).toBe(false);
     });
   });
 
@@ -75,6 +143,50 @@ describe('shortcutDetector', () => {
         altKey: true,
       });
       expect(isRemoveIndentShortcut(event)).toBe(false);
+    });
+  });
+
+  describe('isAddIndent', () => {
+    test('Tab単体を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+      expect(isAddIndent(event)).toBe(true);
+    });
+
+    test('Cmd + ]を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: ']', metaKey: true });
+      expect(isAddIndent(event)).toBe(true);
+    });
+
+    test('Ctrl + ]を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: ']', ctrlKey: true });
+      expect(isAddIndent(event)).toBe(true);
+    });
+
+    test('Shift+Tabは検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+      expect(isAddIndent(event)).toBe(false);
+    });
+  });
+
+  describe('isRemoveIndent', () => {
+    test('Shift+Tabを検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+      expect(isRemoveIndent(event)).toBe(true);
+    });
+
+    test('Cmd + [を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: '[', metaKey: true });
+      expect(isRemoveIndent(event)).toBe(true);
+    });
+
+    test('Ctrl + [を検出する', () => {
+      const event = new KeyboardEvent('keydown', { key: '[', ctrlKey: true });
+      expect(isRemoveIndent(event)).toBe(true);
+    });
+
+    test('Tab単体は検出しない', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+      expect(isRemoveIndent(event)).toBe(false);
     });
   });
 

--- a/src/content/shortcutDetector.ts
+++ b/src/content/shortcutDetector.ts
@@ -20,6 +20,32 @@ export function isTabKey(event: KeyboardEvent): boolean {
 }
 
 /**
+ * インデント追加操作かどうかを判定（Tab単体）
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isAddIndentWithTab(event: KeyboardEvent): boolean {
+  return isTabKey(event) && 
+         !event.shiftKey && 
+         !event.ctrlKey && 
+         !event.altKey && 
+         !event.metaKey;
+}
+
+/**
+ * インデント削除操作かどうかを判定（Shift+Tab）
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isRemoveIndentWithTab(event: KeyboardEvent): boolean {
+  return isTabKey(event) && 
+         event.shiftKey && 
+         !event.ctrlKey && 
+         !event.altKey && 
+         !event.metaKey;
+}
+
+/**
  * インデント追加のショートカット（Cmd/Ctrl + ]）かどうかを判定
  * @param event キーボードイベント
  * @returns 該当する場合true
@@ -44,23 +70,34 @@ export function isRemoveIndentShortcut(event: KeyboardEvent): boolean {
 }
 
 /**
+ * インデント追加操作かどうかを判定（すべてのパターン）
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isAddIndent(event: KeyboardEvent): boolean {
+  return isAddIndentWithTab(event) || isAddIndentShortcut(event);
+}
+
+/**
+ * インデント削除操作かどうかを判定（すべてのパターン）
+ * @param event キーボードイベント
+ * @returns 該当する場合true
+ */
+export function isRemoveIndent(event: KeyboardEvent): boolean {
+  return isRemoveIndentWithTab(event) || isRemoveIndentShortcut(event);
+}
+
+/**
  * キーイベントからインデント操作のタイプを判定
  * @param event キーボードイベント
  * @returns インデント操作のタイプ
  */
 export function detectIndentAction(event: KeyboardEvent): IndentActionType {
-  // Tabキーの場合
-  if (isTabKey(event)) {
-    return event.shiftKey ? IndentActionType.REMOVE : IndentActionType.ADD;
-  }
-  
-  // Cmd/Ctrl + ] の場合
-  if (isAddIndentShortcut(event)) {
+  if (isAddIndent(event)) {
     return IndentActionType.ADD;
   }
   
-  // Cmd/Ctrl + [ の場合
-  if (isRemoveIndentShortcut(event)) {
+  if (isRemoveIndent(event)) {
     return IndentActionType.REMOVE;
   }
   


### PR DESCRIPTION
## Summary
- Tabキー判定において修飾キーの組み合わせを厳密にチェックするように改善
- コードの整理により可読性と再利用性を向上
- ブラウザやOSの標準ショートカットとの干渉を防止

## 変更内容
- `isAddIndentWithTab`/`isRemoveIndentWithTab`に修飾キー（Ctrl、Alt、Meta）のチェックを追加
- Tab単体とShift+Tabのみを正確に検出するように改善
- `isAddIndent`/`isRemoveIndent`で統一的なインデント判定を実装
- `detectIndentAction`関数を簡潔化
- テストケースを追加して修飾キーの組み合わせをカバー（6個のテストケース追加）

## Test plan
- [x] `npm test`で全テストが成功することを確認
- [x] Tab単体でインデント追加が動作することを確認
- [x] Shift+Tabでインデント削除が動作することを確認
- [x] Ctrl+Tab、Alt+Tab、Cmd+Tabなどが誤検出されないことを確認
- [ ] 実際のGitHubページでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)