### PR TITLE
♻️ [Refactoring]: 重複したcreateIndentHandler関数を削除し、関数名をindentHandlerForに変更

### DIFF
--- a/src/content/indentHandler.test.ts
+++ b/src/content/indentHandler.test.ts
@@ -1,96 +1,48 @@
 import { describe, it, expect } from "vitest";
-import { createIndentHandler, createIndentHandlerFromType } from "./indentHandler";
+import { indentHandlerFor } from "./indentHandler";
 import { addIndent, removeIndent } from "./indentProcessor";
 import { IndentActionType } from "./shortcutDetector";
 
 describe("indentHandler", () => {
-  describe("createIndentHandler", () => {
-    it("Tab単体でaddIndentハンドラーを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "Tab",
-        shiftKey: false,
-      });
-      
-      const handler = createIndentHandler(event);
+  describe("indentHandlerFor", () => {
+    it("ADDタイプでaddIndentハンドラーを返す", () => {
+      const handler = indentHandlerFor(IndentActionType.ADD);
       expect(handler).toBe(addIndent);
-      
+    });
+
+    it("REMOVEタイプでremoveIndentハンドラーを返す", () => {
+      const handler = indentHandlerFor(IndentActionType.REMOVE);
+      expect(handler).toBe(removeIndent);
+    });
+
+    it("NONEタイプでnullを返す", () => {
+      const handler = indentHandlerFor(IndentActionType.NONE);
+      expect(handler).toBeNull();
+    });
+
+    it("ADDハンドラーが正しく動作する", () => {
+      const handler = indentHandlerFor(IndentActionType.ADD);
       const result = handler?.("Hello World", 5, 5);
+      
       expect(result).toBeDefined();
       expect(result!.newValue).toBe("Hello   World");
       expect(result!.cursorPosition).toBe(7);
     });
 
-    it("Shift+TabでremoveIndentハンドラーを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "Tab",
-        shiftKey: true,
-      });
-      
-      const handler = createIndentHandler(event);
-      expect(handler).toBe(removeIndent);
-      
+    it("REMOVEハンドラーが正しく動作する", () => {
+      const handler = indentHandlerFor(IndentActionType.REMOVE);
       const result = handler?.("  Hello World", 2, 2);
+      
       expect(result).toBeDefined();
       expect(result!.newValue).toBe("Hello World");
       expect(result!.cursorPosition).toBe(0);
     });
 
-    it("Cmd/Ctrl + ]でaddIndentハンドラーを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "]",
-        metaKey: true,
-      });
-      
-      const handler = createIndentHandler(event);
-      expect(handler).toBe(addIndent);
-    });
-
-    it("Cmd/Ctrl + [でremoveIndentハンドラーを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "[",
-        ctrlKey: true,
-      });
-      
-      const handler = createIndentHandler(event);
-      expect(handler).toBe(removeIndent);
-    });
-
-    it("対象外のキーではnullを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "Enter",
-      });
-      
-      const handler = createIndentHandler(event);
-      expect(handler).toBeNull();
-    });
-
-    it("インデント削除ハンドラーでインデントがない場合はundefinedを返す", () => {
-      const event = new KeyboardEvent("keydown", {
-        key: "Tab",
-        shiftKey: true,
-      });
-      
-      const handler = createIndentHandler(event);
+    it("REMOVEハンドラーでインデントがない場合はundefinedを返す", () => {
+      const handler = indentHandlerFor(IndentActionType.REMOVE);
       const result = handler?.("Hello World", 5, 5);
       
       expect(result).toBeUndefined();
-    });
-  });
-
-  describe("createIndentHandlerFromType", () => {
-    it("ADDタイプでaddIndentハンドラーを返す", () => {
-      const handler = createIndentHandlerFromType(IndentActionType.ADD);
-      expect(handler).toBe(addIndent);
-    });
-
-    it("REMOVEタイプでremoveIndentハンドラーを返す", () => {
-      const handler = createIndentHandlerFromType(IndentActionType.REMOVE);
-      expect(handler).toBe(removeIndent);
-    });
-
-    it("NONEタイプでnullを返す", () => {
-      const handler = createIndentHandlerFromType(IndentActionType.NONE);
-      expect(handler).toBeNull();
     });
   });
 });

--- a/src/content/indentHandler.ts
+++ b/src/content/indentHandler.ts
@@ -1,5 +1,5 @@
 import { IndentResult, addIndent, removeIndent } from "./indentProcessor";
-import { detectIndentAction, IndentActionType } from "./shortcutDetector";
+import { IndentActionType } from "./shortcutDetector";
 
 export type IndentHandler = (
   value: string,
@@ -8,29 +8,11 @@ export type IndentHandler = (
 ) => IndentResult | undefined;
 
 /**
- * KeyboardEventからインデントハンドラーを作成
- * @param event キーボードイベント
- * @returns インデントハンドラー関数
- */
-export function createIndentHandler(event: KeyboardEvent): IndentHandler | null {
-  const actionType = detectIndentAction(event);
-  
-  switch (actionType) {
-    case IndentActionType.ADD:
-      return addIndent;
-    case IndentActionType.REMOVE:
-      return removeIndent;
-    case IndentActionType.NONE:
-      return null;
-  }
-}
-
-/**
- * IndentActionTypeからインデントハンドラーを作成
+ * IndentActionTypeに対応するインデントハンドラーを返す
  * @param actionType インデント操作のタイプ
  * @returns インデントハンドラー関数
  */
-export function createIndentHandlerFromType(actionType: IndentActionType): IndentHandler | null {
+export function indentHandlerFor(actionType: IndentActionType): IndentHandler | null {
   switch (actionType) {
     case IndentActionType.ADD:
       return addIndent;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,7 +1,7 @@
 import { EVENT_TYPES } from "./constants";
 import { getTextAreaElement } from "./textareaDetector";
 import { detectIndentAction, IndentActionType } from "./shortcutDetector";
-import { createIndentHandlerFromType } from "./indentHandler";
+import { indentHandlerFor } from "./indentHandler";
 
 function handleKeyDown(event: KeyboardEvent): void {
   const target = getTextAreaElement(event);
@@ -26,7 +26,7 @@ function handleKeyDown(event: KeyboardEvent): void {
   }
 
   // インデント操作タイプから適切なハンドラーを取得
-  const indentHandler = createIndentHandlerFromType(actionType);
+  const indentHandler = indentHandlerFor(actionType);
   if (!indentHandler) {
     return;
   }


### PR DESCRIPTION
## 概要
- `createIndentHandler`関数を削除（実際には使用されていない重複コード）
- `createIndentHandlerFromType`関数名を`indentHandlerFor`に変更
- テストの責務を適切に修正

## 変更内容

### 1. 重複関数の削除
- `createIndentHandler`関数は`createIndentHandlerFromType`と同じ機能を持ち、実際のコードでは使用されていなかったため削除

### 2. 関数名の改善
- `createIndentHandlerFromType` → `indentHandlerFor`
- より簡潔で読みやすい命名に変更
- 「〜のためのハンドラー」という意図が明確に

### 3. テストの責務修正
- `indentHandler.test.ts`から`detectIndentAction`を使った統合的なテストを削除
- `createIndentHandlerFromType`（現`indentHandlerFor`）の単体テストのみに焦点を当てた構成に

## テスト計画
- [x] 全てのユニットテストが通過することを確認
- [x] ビルドが成功することを確認
- [ ] Chrome拡張機能として動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)