### PR TITLE
♻️ [Refactoring]: .gitignoreにpnpm-storeディレクトリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ CLAUDE.md
 # Dependencies lock file
 pnpm-lock.yaml
 
+# pnpm store directory
+.pnpm-store/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## 概要
`.pnpm-store/`ディレクトリをgit管理外にするため、`.gitignore`に追加しました。

## 変更内容
- `.gitignore`に`.pnpm-store/`を追加

## テストプラン
- [ ] `.pnpm-store/`ディレクトリがgit管理外になっていることを確認
- [ ] `git status`で`.pnpm-store/`が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)