### PR TITLE
✨ [New Feature]: 拡張機能のアイコンを追加

### DIFF
--- a/public/icons/icon-128.svg
+++ b/public/icons/icon-128.svg
@@ -1,0 +1,4 @@
+<svg width="128" height="128" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="128" height="128" rx="16" fill="#2196F3"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="51.2" font-weight="bold" fill="white">GTI</text>
+</svg>

--- a/public/icons/icon-16.svg
+++ b/public/icons/icon-16.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="16" height="16" rx="2" fill="#2196F3"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="6.4" font-weight="bold" fill="white">GTI</text>
+</svg>

--- a/public/icons/icon-48.svg
+++ b/public/icons/icon-48.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="48" height="48" rx="6" fill="#2196F3"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="19.200000000000003" font-weight="bold" fill="white">GTI</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,8 +16,8 @@
   ],
   "options_page": "options.html",
   "icons": {
-    "16": "icon16.png",
-    "48": "icon48.png",
-    "128": "icon128.png"
+    "16": "icons/icon-16.svg",
+    "48": "icons/icon-48.svg",
+    "128": "icons/icon-128.svg"
   }
 }


### PR DESCRIPTION
## 概要
拡張機能のアイコンを追加しました。

## 変更内容
- GTI文字入りのSVGアイコンを作成（16x16, 48x48, 128x128）
- manifest.jsonのアイコン設定をPNGからSVGに変更

## テスト
- [ ] Chrome拡張機能としてインストールして、アイコンが正しく表示されることを確認
- [ ] 各サイズのアイコンが適切な場所で使用されることを確認