### PR TITLE
✨ Tab キー押下時に選択範囲に関わらず常にインデントを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,15 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Documentation folder
+docs/
+
+# General folder
+general/
+
+# OS files
+.DS_Store
+
+# Claude AI files
+.claude/

--- a/src/content/indentProcessor.test.ts
+++ b/src/content/indentProcessor.test.ts
@@ -34,11 +34,11 @@ describe("indentProcessor", () => {
       expect(result.cursorPosition).toBe(7);
     });
 
-    it("選択範囲を置き換えてインデントを追加する", () => {
+    it("選択範囲がある場合でも選択開始位置にインデントを追加する", () => {
       const value = "Hello World";
       const result = addIndent(value, 5, 11);
       
-      expect(result.newValue).toBe("Hello  ");
+      expect(result.newValue).toBe("Hello   World");
       expect(result.cursorPosition).toBe(7);
     });
 
@@ -55,6 +55,22 @@ describe("indentProcessor", () => {
       const result = addIndent(value, 7, 7);
       
       expect(result.newValue).toBe("Line 1\n  Line 2");
+      expect(result.cursorPosition).toBe(9);
+    });
+
+    it("選択範囲が複数文字の場合でも選択開始位置にインデントを追加する", () => {
+      const value = "function test() {}";
+      const result = addIndent(value, 9, 13);
+      
+      expect(result.newValue).toBe("function   test() {}");
+      expect(result.cursorPosition).toBe(11);
+    });
+
+    it("選択範囲が行全体の場合でも選択開始位置にインデントを追加する", () => {
+      const value = "Line 1\nLine 2\nLine 3";
+      const result = addIndent(value, 7, 13);
+      
+      expect(result.newValue).toBe("Line 1\n  Line 2\nLine 3");
       expect(result.cursorPosition).toBe(9);
     });
   });
@@ -92,12 +108,12 @@ describe("indentProcessor", () => {
       expect(result).toBeUndefined();
     });
 
-    it("選択範囲がある場合でもインデントを削除する", () => {
+    it("選択範囲がある場合でも選択開始位置を基準にインデントを削除する", () => {
       const value = "  Hello World";
       const result = removeIndent(value, 2, 7);
       
       expect(result).toBeDefined();
-      expect(result!.newValue).toBe(" World");
+      expect(result!.newValue).toBe("Hello World");
       expect(result!.cursorPosition).toBe(0);
     });
   });

--- a/src/content/indentProcessor.ts
+++ b/src/content/indentProcessor.ts
@@ -32,23 +32,6 @@ function getIndentSize(): number {
   return settings.indentType === 'tab' ? 1 : settings.indentSize;
 }
 
-/**
- * テキストを選択範囲の開始位置と終了位置で分割する
- * @param text 分割対象のテキスト
- * @param start 選択範囲の開始位置
- * @param end 選択範囲の終了位置
- * @returns 選択範囲の前後のテキスト
- */
-function splitTextAtSelection(
-  text: TextValue,
-  start: CursorPosition,
-  end: CursorPosition
-): { before: TextValue; after: TextValue } {
-  return {
-    before: text.substring(0, start),
-    after: text.substring(end),
-  };
-}
 
 /**
  * カーソル位置より前のテキストから現在の行を取得する
@@ -75,6 +58,7 @@ function createIndentResult(
 
 /**
  * テキストの指定位置にインデントを追加する
+ * 選択範囲に関わらず、常にカーソル位置（選択開始位置）にインデントを挿入する
  * @param value 処理対象のテキスト
  * @param selectionStart 選択範囲の開始位置
  * @param selectionEnd 選択範囲の終了位置
@@ -85,7 +69,8 @@ export function addIndent(
   selectionStart: CursorPosition,
   selectionEnd: CursorPosition
 ): IndentResult {
-  const { before, after } = splitTextAtSelection(value, selectionStart, selectionEnd);
+  const before = value.substring(0, selectionStart);
+  const after = value.substring(selectionStart);
   const indentString = getIndentString();
   const indentSize = getIndentSize();
   const newValue = before + indentString + after;
@@ -95,6 +80,7 @@ export function addIndent(
 
 /**
  * 現在の行の先頭からインデントを削除する
+ * 選択範囲に関わらず、選択開始位置を基準にインデントを削除する
  * @param value 処理対象のテキスト
  * @param selectionStart 選択範囲の開始位置
  * @param selectionEnd 選択範囲の終了位置
@@ -105,7 +91,8 @@ export function removeIndent(
   selectionStart: CursorPosition,
   selectionEnd: CursorPosition
 ): IndentResult | undefined {
-  const { before, after } = splitTextAtSelection(value, selectionStart, selectionEnd);
+  const before = value.substring(0, selectionStart);
+  const after = value.substring(selectionStart);
   const currentLine = getCurrentLine(before);
   const indentString = getIndentString();
   const indentSize = getIndentSize();


### PR DESCRIPTION
## 概要
Tab キーの動作を変更し、選択範囲の有無に関わらず常にカーソル位置（選択開始位置）にインデントを挿入するように仕様を変更しました。

## 変更内容
- 選択範囲がある場合でも、選択を無視してカーソル位置にインデント追加
- Shift+Tab も同様に、選択開始位置を基準にインデントを削除

## 実装詳細
### TDD（テスト駆動開発）で実装
1. **Red**: 新仕様に合わせてテストケースを修正
2. **Green**: `addIndent`と`removeIndent`関数を修正してテストを通す
3. **Refactor**: 不要になった`splitTextAtSelection`関数を削除

### 変更ファイル
- `src/content/indentProcessor.ts`: インデント処理ロジックの修正
- `src/content/indentProcessor.test.ts`: テストケースの修正・追加
- `.gitignore`: docsフォルダなどをGit管理から除外

## テスト結果
全142個のテストが成功しています。

🤖 Generated with [Claude Code](https://claude.ai/code)