### PR TITLE
✨ [New Feature]: リリース用スクリプトとnpmコマンドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "release:tag": "node scripts/create-release-tag.js",
+    "version:bump": "node scripts/bump-version.js"
   },
   "keywords": [
     "chrome-extension",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// 引数を取得
+const args = process.argv.slice(2);
+const bumpType = args[0];
+
+if (!bumpType || !['major', 'minor', 'patch'].includes(bumpType)) {
+  console.log('使い方: npm run version:bump [major|minor|patch]');
+  console.log('');
+  console.log('例:');
+  console.log('  npm run version:bump patch   # 0.1.0 → 0.1.1');
+  console.log('  npm run version:bump minor   # 0.1.0 → 0.2.0');
+  console.log('  npm run version:bump major   # 0.1.0 → 1.0.0');
+  process.exit(1);
+}
+
+// バージョンを更新する関数
+function bumpVersion(currentVersion, type) {
+  const parts = currentVersion.split('.').map(Number);
+  
+  switch (type) {
+    case 'major':
+      parts[0]++;
+      parts[1] = 0;
+      parts[2] = 0;
+      break;
+    case 'minor':
+      parts[1]++;
+      parts[2] = 0;
+      break;
+    case 'patch':
+      parts[2]++;
+      break;
+  }
+  
+  return parts.join('.');
+}
+
+// package.jsonを読み込む
+const packageJsonPath = join(dirname(__dirname), 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const currentVersion = packageJson.version;
+const newVersion = bumpVersion(currentVersion, bumpType);
+
+// manifest.jsonを読み込む
+const manifestJsonPath = join(dirname(__dirname), 'public', 'manifest.json');
+const manifestJson = JSON.parse(readFileSync(manifestJsonPath, 'utf-8'));
+
+console.log(`📋 バージョンアップ`);
+console.log(`   現在: ${currentVersion}`);
+console.log(`   新規: ${newVersion}`);
+console.log(`   種別: ${bumpType}`);
+
+// package.jsonを更新
+packageJson.version = newVersion;
+writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+console.log(`✅ package.json を更新しました`);
+
+// manifest.jsonを更新
+manifestJson.version = newVersion;
+writeFileSync(manifestJsonPath, JSON.stringify(manifestJson, null, 2));
+console.log(`✅ manifest.json を更新しました`);
+
+console.log(`\n🎉 バージョン ${newVersion} に更新しました！`);
+console.log(`\n次のステップ:`);
+console.log(`1. 変更をコミット: git add -A && git commit -m "🚀 [Release]: バージョン ${newVersion} にアップデート"`);
+console.log(`2. タグを作成: npm run release:tag`);
+console.log(`3. プッシュ: git push && git push --tags`);

--- a/scripts/create-release-tag.js
+++ b/scripts/create-release-tag.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { parseArgs } from 'util';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// コマンドライン引数をパース
+const { values } = parseArgs({
+  options: {
+    message: {
+      type: 'string',
+      short: 'm'
+    }
+  }
+});
+
+// package.jsonを読み込む
+const packageJsonPath = join(dirname(__dirname), 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const version = packageJson.version;
+
+// manifest.jsonを読み込んで同期を確認
+const manifestJsonPath = join(dirname(__dirname), 'public', 'manifest.json');
+const manifestJson = JSON.parse(readFileSync(manifestJsonPath, 'utf-8'));
+const manifestVersion = manifestJson.version;
+
+// バージョンの同期を確認
+if (version !== manifestVersion) {
+  console.error(`❌ バージョンの不一致が検出されました:`);
+  console.error(`   package.json: ${version}`);
+  console.error(`   manifest.json: ${manifestVersion}`);
+  console.error(`\n両方のファイルでバージョンを同じにしてください。`);
+  process.exit(1);
+}
+
+// タグ名を作成
+const tagName = `v${version}`;
+
+console.log(`📋 リリースタグの作成準備`);
+console.log(`   バージョン: ${version}`);
+console.log(`   タグ名: ${tagName}`);
+
+// 既存のタグを確認
+try {
+  execSync(`git tag -l ${tagName}`, { encoding: 'utf-8' });
+  const existingTag = execSync(`git tag -l ${tagName}`, { encoding: 'utf-8' }).trim();
+  
+  if (existingTag) {
+    console.error(`\n❌ タグ ${tagName} は既に存在します。`);
+    console.error(`   新しいリリースを作成する場合は、package.jsonとmanifest.jsonのバージョンを更新してください。`);
+    process.exit(1);
+  }
+} catch (error) {
+  // タグが存在しない場合は続行
+}
+
+// コミットされていない変更の確認はスキップ（要望により削除）
+
+// タグを作成
+console.log(`\n🏷️  タグを作成中...`);
+try {
+  // アノテーション付きタグを作成（カスタムメッセージまたはデフォルトメッセージ）
+  const tagMessage = values.message || `Release version ${version}`;
+  execSync(`git tag -a ${tagName} -m "${tagMessage}"`, { stdio: 'inherit' });
+  
+  console.log(`✅ タグ ${tagName} を作成しました。`);
+  console.log(`   メッセージ: ${tagMessage}`);
+  
+  // タグをリモートにプッシュ
+  console.log(`\n📤 タグをリモートにプッシュ中...`);
+  execSync(`git push origin ${tagName}`, { stdio: 'inherit' });
+  console.log(`✅ タグをリモートにプッシュしました。`);
+  
+  console.log(`\n🚀 GitHubでリリースを作成するには、以下のURLにアクセスしてください:`);
+  console.log(`   https://github.com/DIO0550/github-tab-indent-extension/releases/new?tag=${tagName}`);
+  
+} catch (error) {
+  console.error(`\n❌ エラーが発生しました: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## 概要
リリースプロセスを簡素化するために、バージョン管理とタグ作成用のスクリプトを追加しました。

## 変更内容
- `scripts/bump-version.js`: バージョンを更新するスクリプト（major/minor/patch）
- `scripts/create-release-tag.js`: GitHubリリース用のタグを作成するスクリプト
- `package.json`: 新しいnpmスクリプトコマンドを追加
  - `npm run version:bump [major|minor|patch]`: バージョンを更新
  - `npm run release:tag`: リリースタグを作成

## 使用方法
1. バージョンを更新: `npm run version:bump patch`
2. リリースタグを作成: `npm run release:tag -m "リリースメッセージ"`

## 関連Issue
なし

## テスト
- [ ] スクリプトが正常に動作することを確認
- [ ] package.jsonとmanifest.jsonのバージョンが同期されることを確認