### PR TITLE
🐛 [Bug fix]: 複数行選択時のインデント処理を修正

### DIFF
--- a/src/content/indentProcessor.test.ts
+++ b/src/content/indentProcessor.test.ts
@@ -73,6 +73,26 @@ describe("indentProcessor", () => {
       expect(result.newValue).toBe("Line 1\n  Line 2\nLine 3");
       expect(result.cursorPosition).toBe(9);
     });
+
+    it("複数行を選択してインデントを追加する", () => {
+      const value = "Line 1\nLine 2\nLine 3";
+      const result = addIndent(value, 0, 20); // 全体を選択
+      
+      expect(result.newValue).toBe("  Line 1\n  Line 2\n  Line 3");
+      expect(result.cursorPosition).toBe(2);
+      expect(result.selectionStart).toBe(0);
+      expect(result.selectionEnd).toBe(26); // 新しい長さに合わせて調整
+    });
+
+    it("複数行の途中から選択してインデントを追加する", () => {
+      const value = "Line 1\nLine 2\nLine 3";
+      const result = addIndent(value, 7, 20); // 2行目から最後まで選択
+      
+      expect(result.newValue).toBe("Line 1\n  Line 2\n  Line 3");
+      expect(result.cursorPosition).toBe(9);
+      expect(result.selectionStart).toBe(7);
+      expect(result.selectionEnd).toBe(24);
+    });
   });
 
   describe("removeIndent", () => {
@@ -115,6 +135,39 @@ describe("indentProcessor", () => {
       expect(result).toBeDefined();
       expect(result!.newValue).toBe("Hello World");
       expect(result!.cursorPosition).toBe(0);
+    });
+
+    it("複数行を選択してインデントを削除する", () => {
+      const value = "  Line 1\n  Line 2\n  Line 3";
+      const result = removeIndent(value, 0, 26); // 全体を選択
+      
+      expect(result).toBeDefined();
+      expect(result!.newValue).toBe("Line 1\nLine 2\nLine 3");
+      expect(result!.cursorPosition).toBe(0);
+      expect(result!.selectionStart).toBe(0);
+      expect(result!.selectionEnd).toBe(20);
+    });
+
+    it("複数行の途中から選択してインデントを削除する", () => {
+      const value = "  Line 1\n  Line 2\n  Line 3";
+      const result = removeIndent(value, 9, 26); // 2行目から最後まで選択
+      
+      expect(result).toBeDefined();
+      expect(result!.newValue).toBe("  Line 1\nLine 2\nLine 3");
+      expect(result!.cursorPosition).toBe(9);
+      expect(result!.selectionStart).toBe(9);
+      expect(result!.selectionEnd).toBe(22);
+    });
+
+    it("インデントがない行を含む複数行選択でインデント削除", () => {
+      const value = "  Line 1\nLine 2\n  Line 3";
+      const result = removeIndent(value, 0, 24); // 全体を選択
+      
+      expect(result).toBeDefined();
+      expect(result!.newValue).toBe("Line 1\nLine 2\nLine 3");
+      expect(result!.cursorPosition).toBe(0);
+      expect(result!.selectionStart).toBe(0);
+      expect(result!.selectionEnd).toBe(20);
     });
   });
 

--- a/src/content/indentProcessor.ts
+++ b/src/content/indentProcessor.ts
@@ -11,6 +11,10 @@ export interface IndentResult {
   newValue: TextValue;
   /** 処理後のカーソル位置 */
   cursorPosition: CursorPosition;
+  /** 処理後の選択開始位置 */
+  selectionStart?: CursorPosition;
+  /** 処理後の選択終了位置 */
+  selectionEnd?: CursorPosition;
 }
 
 /**
@@ -47,18 +51,64 @@ function getCurrentLine(textBeforeCursor: TextValue): TextValue {
  * インデント処理結果のオブジェクトを作成する
  * @param newValue 処理後のテキスト値
  * @param cursorPosition 処理後のカーソル位置
+ * @param selectionStart 処理後の選択開始位置
+ * @param selectionEnd 処理後の選択終了位置
  * @returns インデント処理結果
  */
 function createIndentResult(
   newValue: TextValue,
-  cursorPosition: CursorPosition
+  cursorPosition: CursorPosition,
+  selectionStart?: CursorPosition,
+  selectionEnd?: CursorPosition
 ): IndentResult {
-  return { newValue, cursorPosition };
+  return { newValue, cursorPosition, selectionStart, selectionEnd };
+}
+
+/**
+ * 選択範囲内の各行の先頭を見つける
+ * @param value 全体のテキスト
+ * @param start 選択範囲の開始位置
+ * @param end 選択範囲の終了位置
+ * @returns 各行の開始位置の配列
+ */
+function findLineStarts(value: TextValue, start: CursorPosition, end: CursorPosition): CursorPosition[] {
+  const lineStarts: CursorPosition[] = [];
+  let currentPos = 0;
+  let inSelection = false;
+  
+  // 最初の行を含める
+  if (start === 0) {
+    lineStarts.push(0);
+    inSelection = true;
+  }
+  
+  for (let i = 0; i < value.length; i++) {
+    if (i === start) {
+      // 選択開始位置が行の途中の場合、その行の先頭を見つける
+      const lineStart = value.lastIndexOf('\n', i - 1) + 1;
+      if (lineStarts.indexOf(lineStart) === -1) {
+        lineStarts.push(lineStart);
+      }
+      inSelection = true;
+    }
+    
+    if (value[i] === '\n' && i < end - 1 && inSelection) {
+      // 改行の次の位置（次の行の先頭）
+      lineStarts.push(i + 1);
+    }
+    
+    if (i === end) {
+      inSelection = false;
+      break;
+    }
+  }
+  
+  return lineStarts;
 }
 
 /**
  * テキストの指定位置にインデントを追加する
- * 選択範囲に関わらず、常にカーソル位置（選択開始位置）にインデントを挿入する
+ * 複数行が選択されている場合は、選択範囲内の各行にインデントを追加する
  * @param value 処理対象のテキスト
  * @param selectionStart 選択範囲の開始位置
  * @param selectionEnd 選択範囲の終了位置
@@ -69,40 +119,170 @@ export function addIndent(
   selectionStart: CursorPosition,
   selectionEnd: CursorPosition
 ): IndentResult {
-  const before = value.substring(0, selectionStart);
-  const after = value.substring(selectionStart);
   const indentString = getIndentString();
   const indentSize = getIndentSize();
-  const newValue = before + indentString + after;
   
-  return createIndentResult(newValue, selectionStart + indentSize);
+  // 選択範囲がない場合（カーソルのみ）
+  if (selectionStart === selectionEnd) {
+    const before = value.substring(0, selectionStart);
+    const after = value.substring(selectionStart);
+    const newValue = before + indentString + after;
+    return createIndentResult(newValue, selectionStart + indentSize);
+  }
+  
+  // 選択範囲内に改行が含まれているかチェック
+  const selectedText = value.substring(selectionStart, selectionEnd);
+  const hasNewline = selectedText.includes('\n');
+  
+  // 単一行選択の場合は、従来通りカーソル位置にインデントを挿入
+  if (!hasNewline) {
+    const before = value.substring(0, selectionStart);
+    const after = value.substring(selectionStart);
+    const newValue = before + indentString + after;
+    return createIndentResult(newValue, selectionStart + indentSize);
+  }
+  
+  // 複数行選択の場合
+  const lineStarts = findLineStarts(value, selectionStart, selectionEnd);
+  
+  // 各行にインデントを追加
+  let newValue = value;
+  let offset = 0;
+  let newSelectionStart = selectionStart;
+  let newSelectionEnd = selectionEnd;
+  let firstLineAdjusted = false;
+  
+  for (let i = 0; i < lineStarts.length; i++) {
+    const lineStart = lineStarts[i];
+    const insertPos = lineStart + offset;
+    newValue = newValue.substring(0, insertPos) + indentString + newValue.substring(insertPos);
+    offset += indentSize;
+    
+    // 選択開始位置の調整
+    if (i === 0) {
+      if (lineStart === 0 && selectionStart === 0) {
+        // 最初の行の先頭から選択している場合
+        newSelectionStart = 0;
+      } else if (lineStart < selectionStart) {
+        // 最初の行の途中から選択している場合
+        newSelectionStart = selectionStart + indentSize;
+      }
+    }
+    
+    // 選択終了位置の調整
+    if (lineStart < selectionEnd) {
+      newSelectionEnd += indentSize;
+    }
+  }
+  
+  // カーソル位置の計算（最初の行のインデント後の位置）
+  const firstLineIndentEnd = lineStarts[0] === 0 ? indentSize : selectionStart + indentSize;
+  
+  return createIndentResult(newValue, firstLineIndentEnd, newSelectionStart, newSelectionEnd);
 }
 
 /**
  * 現在の行の先頭からインデントを削除する
- * 選択範囲に関わらず、選択開始位置を基準にインデントを削除する
+ * 複数行が選択されている場合は、選択範囲内の各行からインデントを削除する
  * @param value 処理対象のテキスト
  * @param selectionStart 選択範囲の開始位置
  * @param selectionEnd 選択範囲の終了位置
- * @returns インデント削除後の結果。インデントがない場合はundefined
+ * @returns インデント削除後の結果。すべての行にインデントがない場合はundefined
  */
 export function removeIndent(
   value: TextValue,
   selectionStart: CursorPosition,
   selectionEnd: CursorPosition
 ): IndentResult | undefined {
-  const before = value.substring(0, selectionStart);
-  const after = value.substring(selectionStart);
-  const currentLine = getCurrentLine(before);
   const indentString = getIndentString();
   const indentSize = getIndentSize();
-
-  if (!currentLine.startsWith(indentString)) {
+  
+  // 選択範囲がない場合（カーソルのみ）
+  if (selectionStart === selectionEnd) {
+    const before = value.substring(0, selectionStart);
+    const after = value.substring(selectionStart);
+    const currentLine = getCurrentLine(before);
+    
+    if (!currentLine.startsWith(indentString)) {
+      return undefined;
+    }
+    
+    const newValue = before.substring(0, selectionStart - indentSize) + after;
+    const newCursorPosition = selectionStart - indentSize;
+    
+    return createIndentResult(newValue, newCursorPosition);
+  }
+  
+  // 選択範囲内に改行が含まれているかチェック
+  const selectedText = value.substring(selectionStart, selectionEnd);
+  const hasNewline = selectedText.includes('\n');
+  
+  // 単一行選択の場合は、従来通り選択開始位置を基準にインデントを削除
+  if (!hasNewline) {
+    const before = value.substring(0, selectionStart);
+    const after = value.substring(selectionStart);
+    const currentLine = getCurrentLine(before);
+    
+    if (!currentLine.startsWith(indentString)) {
+      return undefined;
+    }
+    
+    const newValue = before.substring(0, selectionStart - indentSize) + after;
+    const newCursorPosition = selectionStart - indentSize;
+    
+    return createIndentResult(newValue, newCursorPosition);
+  }
+  
+  // 複数行選択の場合
+  const lineStarts = findLineStarts(value, selectionStart, selectionEnd);
+  
+  // 各行からインデントを削除できるかチェック
+  let hasAnyIndent = false;
+  for (const lineStart of lineStarts) {
+    const lineEnd = value.indexOf('\n', lineStart);
+    const line = lineEnd === -1 ? value.substring(lineStart) : value.substring(lineStart, lineEnd);
+    if (line.startsWith(indentString)) {
+      hasAnyIndent = true;
+    }
+  }
+  
+  // インデントがある行が一つもない場合
+  if (!hasAnyIndent) {
     return undefined;
   }
-
-  const newValue = before.substring(0, selectionStart - indentSize) + after;
-  const newCursorPosition = selectionStart - indentSize;
   
-  return createIndentResult(newValue, newCursorPosition);
+  // 各行からインデントを削除
+  let newValue = value;
+  let offset = 0;
+  let newSelectionStart = selectionStart;
+  let newSelectionEnd = selectionEnd;
+  
+  for (let i = 0; i < lineStarts.length; i++) {
+    const lineStart = lineStarts[i];
+    const checkPos = lineStart + offset;
+    if (newValue.substring(checkPos).startsWith(indentString)) {
+      newValue = newValue.substring(0, checkPos) + newValue.substring(checkPos + indentSize);
+      offset -= indentSize;
+      
+      // 選択開始位置の調整
+      if (i === 0) {
+        // 最初の行の場合
+        if (lineStart === 0 && selectionStart <= indentSize) {
+          // 行頭から選択していて、インデント内にカーソルがある場合
+          newSelectionStart = 0;
+        } else if (lineStart < selectionStart) {
+          // 選択開始位置がインデント削除の影響を受ける場合
+          newSelectionStart = Math.max(lineStart, selectionStart - indentSize);
+        }
+      }
+      
+      // 選択終了位置の調整
+      if (lineStart < selectionEnd) {
+        newSelectionEnd -= indentSize;
+      }
+    }
+  }
+  
+  // カーソル位置は選択開始位置に合わせる
+  return createIndentResult(newValue, newSelectionStart, newSelectionStart, newSelectionEnd);
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -14,7 +14,16 @@ import { detectTextAreaContext, isEnabledInContext } from "./contextDetector";
  */
 function updateTextArea(target: EditableElement, result: IndentResult): void {
   target.value = result.newValue;
-  target.selectionStart = target.selectionEnd = result.cursorPosition;
+  
+  // 選択範囲の情報がある場合は選択範囲を維持
+  if (result.selectionStart !== undefined && result.selectionEnd !== undefined) {
+    target.selectionStart = result.selectionStart;
+    target.selectionEnd = result.selectionEnd;
+  } else {
+    // 選択範囲の情報がない場合は、カーソル位置のみ設定
+    target.selectionStart = target.selectionEnd = result.cursorPosition;
+  }
+  
   target.dispatchEvent(new Event(EVENT_TYPES.INPUT, { bubbles: true }));
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## 概要
複数行を選択してインデント操作（Tab/Shift+Tab）を行った際に、選択したすべての行にインデントが適用されるように修正しました。

## 修正内容
- 🚨 複数行選択時のテストケースを追加（TDD）
- 🐛 複数行選択時のインデント処理を実装
- ✨ 選択範囲の保持機能を追加

## 変更詳細

### 1. インデント処理の改善
- 選択範囲内に改行が含まれている場合を検出
- 選択範囲内の各行の先頭を特定する処理を実装
- 各行に対してインデントの追加/削除を適用

### 2. 選択範囲の保持
- `IndentResult`インターフェースに選択範囲情報を追加
- インデント操作後も選択状態を維持
- カーソル位置と選択範囲を適切に調整

### 3. エッジケースの対応
- インデントがない行を含む複数行選択でも正しく動作
- 行の途中から選択を開始した場合も適切に処理

## テスト
- ✅ 全てのユニットテストが成功
- ✅ 複数行選択時の動作を網羅的にテスト

## 関連Issue
Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)