### PR TITLE
🐛 [Bug fix]: オプションページのスクリプトパスを修正

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -99,6 +99,6 @@
     </footer>
   </div>
 
-  <script src="../dist/options.js"></script>
+  <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
issue #23 で報告されていた、オプションページで設定した値が保存されない問題を修正しました。

## 変更内容
- `public/options.html` のスクリプトパスを修正
  - 誤: `<script src="../dist/options.js"></script>`
  - 正: `<script src="options.js"></script>`

## 原因
オプションページのHTMLファイルで、JavaScriptファイルのパスが誤っていたため、
オプションページのスクリプトが読み込まれず、設定の保存・読み込み機能が動作していませんでした。

## テスト
- [x] `pnpm test` が全て成功することを確認
- [x] ビルドが正常に完了することを確認
- [x] 実際に拡張機能をインストールして、オプションページで設定が保存されることを確認

## 関連issue
- Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)